### PR TITLE
send help menu when receiving unknown commands / text / documents

### DIFF
--- a/bot/src/main/java/org/telegram/bot/api/Parser.java
+++ b/bot/src/main/java/org/telegram/bot/api/Parser.java
@@ -1,7 +1,11 @@
 package org.telegram.bot.api;
 
 import org.telegram.bot.api.TelegramLongPollingThreadBot;
+import org.telegram.bot.commands.HelpCommand;
+import org.telegram.bot.messages.ContentMessage;
+import org.telegram.bot.messages.Message;
 import org.telegram.telegrambots.api.methods.send.SendChatAction;
+import org.telegram.telegrambots.api.methods.send.SendMessage;
 import org.telegram.telegrambots.api.objects.Chat;
 import org.telegram.telegrambots.api.objects.Update;
 import org.telegram.telegrambots.api.objects.User;
@@ -58,7 +62,20 @@ public abstract class Parser implements Runnable {
 
     public void run() {
         if (!this.parse()) {
-            //TODO set help command with attributes
+            Message message = new Message("unknown");
+            String messageText = message.getContent(user.getId(), false);
+            try {
+                SendMessages.getInstance().addMessage(message.calculateHash(), messageText, chat.getId().toString(), this.bot);
+            } catch (InterruptedException e) {
+                BotLogger.error(LOGTAG, e);
+            }
+
+            this.arguments = new String[]{};
+            try {
+                this.commandConstructor = (Constructor) HelpCommand.class.getConstructor();
+            } catch (Exception e) {
+                BotLogger.error(LOGTAG, e);
+            }
         }
         this.executeCommand();
     }

--- a/bot/src/main/resources/english.xml
+++ b/bot/src/main/resources/english.xml
@@ -35,6 +35,10 @@
 
 <language xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="language.xsd">
     <name>en</name>
+    <command_message command="unknown">
+        <command_description>This text is send, when the bot receives a text messages.</command_description>
+        <command_content>I can't handle this. Here you have some instructions on how to work with me: </command_content>
+    </command_message>
     <command_message command="cancel_command">
         <command_description>Cancel the running command (e.g. uploading of a new picture).</command_description>
     </command_message>

--- a/bot/src/main/resources/german.xml
+++ b/bot/src/main/resources/german.xml
@@ -35,6 +35,10 @@
 
 <language xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="language.xsd">
     <name>ger</name>
+    <command_message command="unknown">
+        <command_description>Dieser Text wird gesendet, wenn der Bot eine Textnachricht empfängt.</command_description>
+        <command_content>Damit kann ich nichts anfangen. Hier ist das Hilfe-Menu: </command_content>
+    </command_message>
     <command_message command="cancel_command">
         <command_description>Bricht den laufenden Befehl ab (z. Bsp. das Hochladen eines Bildes).</command_description>
     </command_message>


### PR DESCRIPTION
Added routine to the parser that sends a message + help menu if a user
sends an unknown command or sends unexpected text / documents.